### PR TITLE
[+] WebSocketClient thread naming

### DIFF
--- a/cbpro/websocket_client.py
+++ b/cbpro/websocket_client.py
@@ -19,7 +19,8 @@ from cbpro.cbpro_auth import get_auth_headers
 
 class WebsocketClient(object):
     def __init__(self, url="wss://ws-feed.pro.coinbase.com", products=None, message_type="subscribe", mongo_collection=None,
-                 should_print=True, auth=False, api_key="", api_secret="", api_passphrase="", channels=None):
+                 should_print=True, auth=False, api_key="", api_secret="", api_passphrase="", channels=None,
+                 thread_name='WebsocketClient', keepalive_thread_name='WebsocketClientKeepAlive):
         self.url = url
         self.products = products
         self.channels = channels
@@ -43,8 +44,8 @@ class WebsocketClient(object):
 
         self.stop = False
         self.on_open()
-        self.thread = Thread(target=_go)
-        self.keepalive = Thread(target=self._keepalive)
+        self.thread = Thread(target=_go, name=thread_name)
+        self.keepalive = Thread(target=self._keepalive, name=keeaplive_thread_name)
         self.thread.start()
 
     def _connect(self):


### PR DESCRIPTION
1. Added kwarg in the constructor of the WSC to name the thread on which it runs
2. Added kwarfg for the keepalive thread.